### PR TITLE
Fix: Some way to break block doesn't being handled

### DIFF
--- a/src/main/java/io/ib67/astralflow/hook/HookType.java
+++ b/src/main/java/io/ib67/astralflow/hook/HookType.java
@@ -27,8 +27,7 @@ import io.ib67.astralflow.api.events.MachineBlockPlaceEvent;
 import io.ib67.astralflow.hook.event.server.SaveDataEvent;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -47,6 +46,7 @@ import java.util.function.Consumer;
  * <code>
  * HookType.XXX.register( event -> {xxxx} );
  * </code>
+ * One hook can be called in several conditions, such as (BlockBreakEvent, BlockBurnEvent) -> BLOCK_BREAK
  *
  * @param <T>
  */
@@ -100,6 +100,18 @@ public final class HookType<T> {
     public static final HookType<BlockBreakEvent> BLOCK_BREAK = new HookType<>("Block Break");
     public static final HookType<BlockPlaceEvent> BLOCK_PLACE = new HookType<>("Block Place");
     public static final HookType<ProjectileHitEvent> PROJECTILE_HIT = new HookType<>("Projectile Hit");
+    /**
+     * It also calls {@link #BLOCK_BREAK}
+     */
+    public static final HookType<BlockBurnEvent> BLOCK_BURNT = new HookType<>("Block Burn");
+    /**
+     * It also calls {@link #BLOCK_BREAK}
+     */
+    public static final HookType<BlockFadeEvent> BLOCK_FADE = new HookType<>("Block Fade");
+    /**
+     * It also calls {@link #BLOCK_BREAK}
+     */
+    public static final HookType<BlockExplodeEvent> BLOCK_EXPLODE = new HookType<>("Block Explode");
 
     /**
      * A name for exceptions.

--- a/src/main/java/io/ib67/astralflow/internal/listener/BlockListener.java
+++ b/src/main/java/io/ib67/astralflow/internal/listener/BlockListener.java
@@ -38,10 +38,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPistonExtendEvent;
-import org.bukkit.event.block.BlockPistonRetractEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.*;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -53,6 +50,7 @@ import java.util.Comparator;
 public final class BlockListener implements Listener {
     private final AstralFlowAPI flow;
 
+    // block placements.
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
         event.setCancelled(
@@ -92,6 +90,8 @@ public final class BlockListener implements Listener {
         }
     }
 
+    // block destroy
+
     @EventHandler(priority = EventPriority.HIGH)
     public void onBlockBreak(BlockBreakEvent event) {
         var clickedBlock = event.getBlock();
@@ -112,6 +112,40 @@ public final class BlockListener implements Listener {
             }
             event.setDropItems(evt.isDropItem());
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBlockBurnt(BlockBurnEvent event) {
+        var evt = new BlockBreakEvent(event.getBlock(), null);
+        onBlockBreak(evt);
+        if (evt.isCancelled()) {
+            event.setCancelled(true);
+        }
+        flow.callHooks(HookType.BLOCK_BURNT, event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBlockFade(BlockFadeEvent event) {
+        var evt = new BlockBreakEvent(event.getBlock(), null);
+        onBlockBreak(evt);
+        if (evt.isCancelled()) {
+            event.setCancelled(true);
+        }
+        flow.callHooks(HookType.BLOCK_FADE, event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBlockExplode(BlockExplodeEvent event) {
+        var it = event.blockList().iterator();
+        while (it.hasNext()) {
+            var block = it.next();
+            var evt = new BlockBreakEvent(block, null);
+            onBlockBreak(evt);
+            if (evt.isCancelled()) {
+                it.remove();
+            }
+        }
+        flow.callHooks(HookType.BLOCK_EXPLODE, event);
     }
 
     // for slime blocks. Thanks to `Plugindustry/WheelCore` for their codes.


### PR DESCRIPTION
Enriches HookType for Breaking Blocks. (burn, fade and explode)

This closes #123 