### PR TITLE
Config for disabling machineMap resizing

### DIFF
--- a/src/main/java/io/ib67/astralflow/AstralFlow.java
+++ b/src/main/java/io/ib67/astralflow/AstralFlow.java
@@ -271,7 +271,12 @@ public final class AstralFlow extends JavaPlugin implements AstralFlowAPI {
                 configuration.getOptimization().getChunkMapCapacity(),
                 configuration.getOptimization().isAllowChunkMapResizing()
         );
-        machineManager = new MachineManagerImpl(machineStorage, configuration.getOptimization().getInitialMachineCapacity(), tickManager);
+        machineManager = new MachineManagerImpl(
+                machineStorage, tickManager,
+                configuration.getOptimization().getInitialMachineCapacity(), configuration.getOptimization().isAllowMachineMapResizing(),
+                configuration.getOptimization().getChunkMapCapacity(),
+                configuration.getOptimization().isAllowChunkMapResizing()
+        );
     }
 
     private void loadItemManager() {

--- a/src/main/java/io/ib67/astralflow/internal/config/AstralFlowConfiguration.java
+++ b/src/main/java/io/ib67/astralflow/internal/config/AstralFlowConfiguration.java
@@ -101,7 +101,7 @@ public final class AstralFlowConfiguration {
          * Machines usually have lesser elements, so it's recommended to enable this feature.
          * If you don't know what this means, don't change this value.
          */
-        @SerializedName("chunk-map-resizing")
+        @SerializedName("machine-map-resizing")
         private final boolean allowMachineMapResizing = true;
 
         /**

--- a/src/main/java/io/ib67/astralflow/internal/config/AstralFlowConfiguration.java
+++ b/src/main/java/io/ib67/astralflow/internal/config/AstralFlowConfiguration.java
@@ -96,6 +96,15 @@ public final class AstralFlowConfiguration {
         private final int initialMachineCapacity = 32;
 
         /**
+         * Can machine map be resized?
+         * Resizing happens when the elements amount reaches capacity * 0.75F. For resizing, the map will copy all values and re-process them, which may cause a performance hit.
+         * Machines usually have lesser elements, so it's recommended to enable this feature.
+         * If you don't know what this means, don't change this value.
+         */
+        @SerializedName("chunk-map-resizing")
+        private final boolean allowMachineMapResizing = true;
+
+        /**
          * How much chunk slots should be initialized at start-up
          * This feature determines the default capacity of the hashmap holding chunks, Higher value may provide a better performance but may cause higher memory usage.
          * You can decrease this to save memory.

--- a/src/main/java/io/ib67/astralflow/util/WeakHashSet.java
+++ b/src/main/java/io/ib67/astralflow/util/WeakHashSet.java
@@ -21,6 +21,7 @@
 
 package io.ib67.astralflow.util;
 
+import io.ib67.util.reflection.AccessibleClass;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -113,5 +114,9 @@ public final class WeakHashSet<E> implements Set<E> {
     @Override
     public void clear() {
         map.clear();
+    }
+
+    public void disableResizing() {
+        AccessibleClass.of(WeakHashMap.class).virtualField("threshold").set((WeakHashMap<?, ?>) map, Integer.MAX_VALUE);
     }
 }

--- a/src/test/java/io/ib67/astralflow/machine/AutoFactoryTest.java
+++ b/src/test/java/io/ib67/astralflow/machine/AutoFactoryTest.java
@@ -27,13 +27,10 @@ import io.ib67.astralflow.machines.AutoFactory;
 import io.ib67.astralflow.machines.IMachine;
 import io.ib67.astralflow.machines.MachineProperty;
 import io.ib67.astralflow.test.TestUtil;
-import org.bukkit.Location;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-
-import java.util.UUID;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public final class AutoFactoryTest {
@@ -74,8 +71,7 @@ public final class AutoFactoryTest {
     static class MachineC extends AbstractMachine {
 
         protected MachineC() {
-            super(UUID.randomUUID(), new Location(null, 1, 2, 3)); // do not do this in production
-
+            super(null); // do not do this in production
         }
 
         @Override

--- a/src/test/java/io/ib67/astralflow/storage/ChunkBasedMachineStorageTest.java
+++ b/src/test/java/io/ib67/astralflow/storage/ChunkBasedMachineStorageTest.java
@@ -97,7 +97,7 @@ public final class ChunkBasedMachineStorageTest {
         Files.createFile(file);
         var randomLoc = new Location(Bukkit.getWorld("world"), ThreadLocalRandom.current().nextInt(3000), 1, ThreadLocalRandom.current().nextInt(3000));
         var storage = new ChunkBasedMachineStorage(new MachineCache(file), AstralFlow.getInstance().getFactories(), MachineStorageType.JSON, 256, false);
-        var machineManager = new MachineManagerImpl(storage, 16, null);
+        var machineManager = new MachineManagerImpl(storage, null, 16, true, 256, true);
         storage.initChunk(randomLoc.getChunk());
         var machine = new DummyStatefulMachine(MachineProperty
                 .builder()


### PR DESCRIPTION
This closes #134 

Providing a configuration `allowMachineMapResizing` for users to control whether it can resize, this may help for server holding tons of increasing machines