### PR TITLE
Call `BlockDropItemEvent` for broken machines

### DIFF
--- a/src/main/java/io/ib67/astralflow/api/item/machine/MachineItem.java
+++ b/src/main/java/io/ib67/astralflow/api/item/machine/MachineItem.java
@@ -36,10 +36,14 @@ import io.ib67.astralflow.machines.Tickless;
 import io.ib67.astralflow.util.Blocks;
 import lombok.Getter;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Item;
+import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -127,6 +131,17 @@ public class MachineItem extends ItemBase {
         emptyState.setData(state.getData());
         emptyState.setMachineType(machine.getType().getName());
         var loc = event.getBlock().getLocation();
-        loc.getWorld().dropItemNaturally(loc, item.asItemStack());
+        var actuallyDroppedItems = List.of(loc.getWorld().dropItemNaturally(loc, item.asItemStack()));
+        var itemToDrop = new ArrayList<>(actuallyDroppedItems);
+        if (event.getPlayer() != null) {
+            var bdie = new BlockDropItemEvent(loc.getBlock(), loc.getBlock().getState(), event.getPlayer(), itemToDrop);
+            Bukkit.getPluginManager().callEvent(bdie);
+            if (bdie.isCancelled() || itemToDrop.isEmpty()) {
+                for (Item actuallyDroppedItem : actuallyDroppedItems) {
+                    actuallyDroppedItem.remove();
+                }
+            }
+        }
+
     }
 }

--- a/src/main/java/io/ib67/astralflow/hook/HookType.java
+++ b/src/main/java/io/ib67/astralflow/hook/HookType.java
@@ -99,6 +99,7 @@ public final class HookType<T> {
     // For blocks
     public static final HookType<BlockBreakEvent> BLOCK_BREAK = new HookType<>("Block Break");
     public static final HookType<BlockPlaceEvent> BLOCK_PLACE = new HookType<>("Block Place");
+    public static final HookType<BlockDropItemEvent> BLOCK_DROP_ITEM = new HookType<>("Block Drop Item");
     public static final HookType<ProjectileHitEvent> PROJECTILE_HIT = new HookType<>("Projectile Hit");
     /**
      * It also calls {@link #BLOCK_BREAK}

--- a/src/main/java/io/ib67/astralflow/internal/listener/BlockListener.java
+++ b/src/main/java/io/ib67/astralflow/internal/listener/BlockListener.java
@@ -167,6 +167,12 @@ public final class BlockListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockDropItem(BlockDropItemEvent event) {
+        event.setCancelled(AstralFlow.getInstance().callHooks(HookType.BLOCK_DROP_ITEM, event));
+
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPistonPull(BlockPistonRetractEvent event) {
         event.setCancelled(onBlockMove(event.getBlocks(), event.getDirection()));
     }

--- a/src/test/java/io/ib67/astralflow/item/machine/MachineItemTest.java
+++ b/src/test/java/io/ib67/astralflow/item/machine/MachineItemTest.java
@@ -25,6 +25,7 @@ package io.ib67.astralflow.item.machine;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import io.ib67.astralflow.api.AstralHelper;
 import io.ib67.astralflow.api.item.machine.MachineItem;
+import io.ib67.astralflow.hook.HookType;
 import io.ib67.astralflow.item.ItemKey;
 import io.ib67.astralflow.item.ItemKeys;
 import io.ib67.astralflow.test.TestUtil;
@@ -32,17 +33,25 @@ import io.ib67.astralflow.util.ItemStacks;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Item;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MachineItemTest {
     private static final ItemKey TEST_MACHINE_ITEM = ItemKeys.from("testitem:test_machine_item");
     private ItemKey machineItem;
     private World anyWorld;
+    private Block block;
 
     @BeforeAll
     public void setup() {
@@ -56,10 +65,11 @@ public class MachineItemTest {
     }
 
     @Test
+    @Order(1)
     public void testMachineSetup() {
-        var block = anyWorld.getBlockAt(0, 0, 0);
+        block = anyWorld.getBlockAt(0, 0, 0);
         var exampleItem = machineItem.createNewItem();
-        Assertions.assertTrue(AstralHelper.isItem(exampleItem.asItemStack()), "Test Item Allocation");
+        assertTrue(AstralHelper.isItem(exampleItem.asItemStack()), "Test Item Allocation");
         var player = MockBukkit.getMock().addPlayer();
         var blockPlaceEvent = new BlockPlaceEvent(
                 block,
@@ -71,6 +81,23 @@ public class MachineItemTest {
                 null
         );
         Bukkit.getPluginManager().callEvent(blockPlaceEvent);
-        Assertions.assertTrue(AstralHelper.hasMachine(block), "Test Block Placement");
+        assertTrue(AstralHelper.hasMachine(block), "Test Block Placement");
+    }
+
+    @Test
+    @Order(2)
+    public void testMachineBreak() {
+        AtomicReference<List<Item>> results = new AtomicReference<>();
+        HookType.BLOCK_DROP_ITEM.register(bdie -> {
+            results.set(bdie.getItems());
+        });
+        block.breakNaturally();
+        var bbe = new BlockBreakEvent(block, MockBukkit.getMock().addPlayer());
+        Bukkit.getPluginManager().callEvent(bbe);
+        assertTrue(results.get().size() > 0, "Size is bigger than zero");
+        var item = results.get().get(0).getItemStack();
+        assertTrue(AstralHelper.isItem(item), "The first one is a machine item");
+        assertFalse(AstralHelper.hasMachine(block), "Block is removed.");
+
     }
 }

--- a/src/test/java/io/ib67/astralflow/item/machine/MachineItemTest.java
+++ b/src/test/java/io/ib67/astralflow/item/machine/MachineItemTest.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *   AstralFlow - The plugin enriches bukkit servers
+ *   Copyright (C) 2022 The Inlined Lambdas and Contributors
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2.1 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *   USA
+ */
+
+package io.ib67.astralflow.item.machine;
+
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import io.ib67.astralflow.api.AstralHelper;
+import io.ib67.astralflow.api.item.machine.MachineItem;
+import io.ib67.astralflow.item.ItemKey;
+import io.ib67.astralflow.item.ItemKeys;
+import io.ib67.astralflow.test.TestUtil;
+import io.ib67.astralflow.util.ItemStacks;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MachineItemTest {
+    private static final ItemKey TEST_MACHINE_ITEM = ItemKeys.from("testitem:test_machine_item");
+    private ItemKey machineItem;
+    private World anyWorld;
+
+    @BeforeAll
+    public void setup() {
+        TestUtil.init();
+        machineItem = MachineItem.registerItem(TEST_MACHINE_ITEM,
+                ItemStacks.builder(Material.WHITE_WOOL)
+                        .build(),
+                SimpleStatelessMachine.class
+        );
+        anyWorld = MockBukkit.getMock().addSimpleWorld("testmi");
+    }
+
+    @Test
+    public void testMachineSetup() {
+        var block = anyWorld.getBlockAt(0, 0, 0);
+        var exampleItem = machineItem.createNewItem();
+        Assertions.assertTrue(AstralHelper.isItem(exampleItem.asItemStack()), "Test Item Allocation");
+        var player = MockBukkit.getMock().addPlayer();
+        var blockPlaceEvent = new BlockPlaceEvent(
+                block,
+                null,
+                block,
+                exampleItem.asItemStack(),
+                player,
+                false,
+                null
+        );
+        Bukkit.getPluginManager().callEvent(blockPlaceEvent);
+        Assertions.assertTrue(AstralHelper.hasMachine(block), "Test Block Placement");
+    }
+}

--- a/src/test/java/io/ib67/astralflow/item/machine/SimpleStatelessMachine.java
+++ b/src/test/java/io/ib67/astralflow/item/machine/SimpleStatelessMachine.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *   AstralFlow - The plugin enriches bukkit servers
+ *   Copyright (C) 2022 The Inlined Lambdas and Contributors
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2.1 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *   USA
+ */
+
+package io.ib67.astralflow.item.machine;
+
+import io.ib67.astralflow.machines.AbstractMachine;
+import io.ib67.astralflow.machines.AutoFactory;
+import io.ib67.astralflow.machines.IMachine;
+import io.ib67.astralflow.machines.MachineProperty;
+
+@AutoFactory
+public class SimpleStatelessMachine extends AbstractMachine {
+    protected SimpleStatelessMachine(MachineProperty property) {
+        super(property);
+    }
+
+    @Override
+    public void update(IMachine self) {
+
+    }
+}


### PR DESCRIPTION
only call if there're players involved.  
This resolves #127 